### PR TITLE
feat: main-layout 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ function App() {
           <Route path="/login" />
           <Route path="/" />
           <Route path="/signup" />
+          <Route path="/success" />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,17 @@
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import MainLayout from './components/template/MainLayout';
+
 function App() {
-  return <></>;
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route element={<MainLayout />}>
+          <Route path="/login" />
+          <Route path="/" />
+        </Route>
+      </Routes>
+    </BrowserRouter>
+  );
 }
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ function App() {
         <Route element={<MainLayout />}>
           <Route path="/login" />
           <Route path="/" />
+          <Route path="/signup" />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/components/molecules/MainHeader.tsx
+++ b/src/components/molecules/MainHeader.tsx
@@ -13,5 +13,9 @@ export default MainHeader;
 
 const MainHeaderContainer = styled.div`
   width: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
   padding: 20px 40px;
+  background-color: ${({ theme }) => theme.colors.darkgray2};
 `;

--- a/src/components/molecules/SearchBar.tsx
+++ b/src/components/molecules/SearchBar.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import search from '../../assets/images/search.svg';
-import CancleButton from '../atoms/CancelButton';
+import CancelButton from '../atoms/CancelButton';
 
 interface SearchBarProps {
   onChange: () => void;
@@ -14,7 +14,7 @@ const SearchBar = ({ onChange, onSubmit, value }: SearchBarProps) => {
     <SearchBarContainer onSubmit={onSubmit}>
       <SearchImg src={search} />
       <Input value={value} onChange={onChange} />
-      <CancleButton onClick={handleClick} />
+      <CancelButton onClick={handleClick} />
     </SearchBarContainer>
   );
 };

--- a/src/components/organisms/Footer.tsx
+++ b/src/components/organisms/Footer.tsx
@@ -42,6 +42,9 @@ export default Footer;
 
 const FooterContainer = styled.div`
   width: 100%;
+  position: fixed;
+  left: 0;
+  bottom: 0;
   padding: 12px 40px;
   display: flex;
   align-items: center;

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -1,0 +1,105 @@
+import styled from 'styled-components';
+import { FormEventHandler } from 'react';
+import Logo from '../atoms/Logo';
+import CancelButton from '../atoms/CancelButton';
+import { ReactComponent as ChevronSvg } from '../../assets/images/chevron.svg';
+import { ReactComponent as SearchSvg } from '../../assets/images/search.svg';
+
+type DetailHeaderProps = {
+  title?: string;
+  onPrevClick: () => void;
+};
+
+type SearchBarProps = {
+  onSearchSubmit: () => FormEventHandler<HTMLFormElement>;
+  value: string;
+  setSearchInput: React.Dispatch<React.SetStateAction<string>>;
+};
+
+type HeaderProps = {
+  path: string;
+} & (SearchBarProps | DetailHeaderProps);
+
+export const Header = ({ path, ...props }: HeaderProps) => {
+  const mainHeader = ['/login', '/', 'mypage'];
+  const searchHeader = ['/search'];
+  const detailHeader = ['/signup'];
+  const renderInner = () => {
+    if (searchHeader.includes(path)) {
+      const { onSearchSubmit, value, setSearchInput } = props as SearchBarProps;
+      const handleCancelClick = () => {
+        setSearchInput('');
+      };
+
+      const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setSearchInput(e.target.value);
+      };
+      return (
+        <SearchBarContainer onSubmit={onSearchSubmit}>
+          <SearchImg />
+          <Input value={value} onChange={handleSearchChange} />
+          <CancelButton onClick={handleCancelClick} />
+        </SearchBarContainer>
+      );
+    } else if (detailHeader.includes(path)) {
+      const { onPrevClick, title } = props as DetailHeaderProps;
+      return (
+        <HeaderContainer>
+          <PrevButton onClick={onPrevClick}>
+            <ChevronImg />
+            <PrevTitle>{title}</PrevTitle>
+          </PrevButton>
+        </HeaderContainer>
+      );
+    } else if (mainHeader.includes(path)) {
+      return (
+        <HeaderContainer>
+          <Logo />
+        </HeaderContainer>
+      );
+    }
+  };
+  return <>{renderInner()}</>;
+};
+
+const HeaderContainer = styled.div`
+  width: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  padding: 20px 40px;
+  background-color: ${({ theme }) => theme.colors.darkgray2};
+`;
+
+const PrevButton = styled.button`
+  display: flex;
+  align-items: center;
+`;
+
+const ChevronImg = styled(ChevronSvg)`
+  margin-right: 12px;
+`;
+
+const PrevTitle = styled.div`
+  font-size: 16px;
+  font-weight: 500;
+  color: white;
+`;
+
+const SearchBarContainer = styled.form`
+  display: flex;
+  align-items: center;
+  background-color: ${({ theme }) => theme.colors.darkgray4};
+  border-radius: 999px;
+  padding: 8px;
+`;
+
+const SearchImg = styled(SearchSvg)`
+  margin-right: 10px;
+`;
+
+const Input = styled.input`
+  margin-right: 8px;
+  font-size: 16px;
+  color: white;
+`;

--- a/src/components/template/MainLayout.tsx
+++ b/src/components/template/MainLayout.tsx
@@ -1,0 +1,24 @@
+import { Outlet, useLocation } from 'react-router-dom';
+import styled from 'styled-components';
+import MainHeader from '../molecules/MainHeader';
+import Footer from '../organisms/Footer';
+
+const MainLayout = () => {
+  const hasFooter = ['/', 'search', 'mypage'];
+  const location = useLocation();
+  return (
+    <Container>
+      <MainHeader />
+      <Outlet />
+      {hasFooter.includes(location.pathname) && <Footer />}
+    </Container>
+  );
+};
+
+export default MainLayout;
+
+const Container = styled.div`
+  width: 100%;
+  height: 100vh;
+  position: relative;
+`;

--- a/src/components/template/MainLayout.tsx
+++ b/src/components/template/MainLayout.tsx
@@ -1,14 +1,25 @@
-import { Outlet, useLocation } from 'react-router-dom';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import MainHeader from '../molecules/MainHeader';
+import { useState } from 'react';
 import Footer from '../organisms/Footer';
+import { Header } from '../organisms/Header';
 
 const MainLayout = () => {
   const hasFooter = ['/', 'search', 'mypage'];
   const location = useLocation();
+  const [searchInput, setSearchInput] = useState('');
+  const navigate = useNavigate();
+  const handlePrevClick = () => {
+    navigate(-1);
+  };
   return (
     <Container>
-      <MainHeader />
+      <Header
+        path={location.pathname}
+        value={searchInput}
+        setSearchInput={setSearchInput}
+        onPrevClick={handlePrevClick}
+      />
       <Outlet />
       {hasFooter.includes(location.pathname) && <Footer />}
     </Container>

--- a/src/components/template/MainLayout.tsx
+++ b/src/components/template/MainLayout.tsx
@@ -6,6 +6,7 @@ import { Header } from '../organisms/Header';
 
 const MainLayout = () => {
   const hasFooter = ['/', 'search', 'mypage'];
+  const hasHeader = ['success'];
   const location = useLocation();
   const [searchInput, setSearchInput] = useState('');
   const navigate = useNavigate();
@@ -14,12 +15,14 @@ const MainLayout = () => {
   };
   return (
     <Container>
-      <Header
-        path={location.pathname}
-        value={searchInput}
-        setSearchInput={setSearchInput}
-        onPrevClick={handlePrevClick}
-      />
+      {!hasHeader.includes(location.pathname) && (
+        <Header
+          path={location.pathname}
+          value={searchInput}
+          setSearchInput={setSearchInput}
+          onPrevClick={handlePrevClick}
+        />
+      )}
       <Outlet />
       {hasFooter.includes(location.pathname) && <Footer />}
     </Container>


### PR DESCRIPTION
- Main-layout 구현했습니다.
  - header,footer position fiexd로 수정했습니다.
  
- Header component를 맨위에서 한번만 부르기 위해서 기존에 만든 3개의 header를  하나의 컴포넌트로 합쳤습니다.
  - header없는 페이지까지 고려해서 hasHeader를 통해 layout에서 한번더 구분지었습니다.
  -  추후에 path값이 변경되면 그때 추가하면서 바꾸도록 해보겠습니다.
  
  