### PR TITLE
feat: movie-survey-from,template 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import LoginTemplate from './components/template/LoginTemplate';
 import SignupTemplate from './components/template/SignupTemplate';
 import SucessTemplate from './components/template/SucessTemplate';
 import GenreSurveyTemplate from './components/template/GenreSurveyTemplate';
+import MovieSurveyTemplate from './components/template/MovieSurveyTemplate';
 
 function App() {
   return (
@@ -18,7 +19,10 @@ function App() {
             <Route path="/signup/success" element={<SucessTemplate />} />
             <Route path="/survey/success" element={<SucessTemplate />} />
             <Route path="/survey/genre" element={<GenreSurveyTemplate />} />
-            <Route path="/survey/movies/:id" />
+            <Route
+              path="/survey/movies/:id"
+              element={<MovieSurveyTemplate />}
+            />
           </Route>
         </Routes>
       </BrowserRouter>

--- a/src/components/atoms/MovieSurveyImg.tsx
+++ b/src/components/atoms/MovieSurveyImg.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import check from '../../assets/images/check.svg';
+import { ReactComponent as CheckSvg } from '../../assets/images/check.svg';
 
 interface SurveyImgProps {
   isChecked?: boolean;
@@ -12,7 +12,7 @@ const MovieSurveyImg = ({ isChecked, src }: SurveyImgProps) => {
       {isChecked && (
         <>
           <Background />
-          <CheckImg src={check} />
+          <CheckImg />
         </>
       )}
       <SurveyImage src={src} />
@@ -24,8 +24,8 @@ export default MovieSurveyImg;
 
 const SurveyImgContainer = styled.div`
   position: relative;
-  width: '88px';
-  height: '132px';
+  width: 88px;
+  height: 132px;
   border-radius: 14px;
 `;
 
@@ -46,7 +46,7 @@ const SurveyImage = styled.img`
   border-radius: 14px;
 `;
 
-const CheckImg = styled.img`
+const CheckImg = styled(CheckSvg)`
   z-index: 5;
   position: absolute;
   top: 50%;

--- a/src/components/atoms/PrimaryButton.tsx
+++ b/src/components/atoms/PrimaryButton.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 export interface PrimaryButtonProps {
   type?: 'submit' | 'button';
-  children: string;
+  children: React.ReactNode;
   onClick?: () => void;
   state?: boolean;
   size: 'large' | 'medium' | 'small';

--- a/src/components/atoms/PrimaryButton.tsx
+++ b/src/components/atoms/PrimaryButton.tsx
@@ -34,17 +34,28 @@ const Button = styled.button<{
   $isActive?: boolean;
   size: PrimaryButtonProps['size'];
 }>`
-  width: max-content;
+  min-width: ${({ size }) => {
+    switch (size) {
+      case 'large':
+        return '280px';
+      case 'medium':
+        return '120px';
+      case 'small':
+        return '90px';
+      default:
+        return '120px';
+    }
+  }};
   padding: ${({ size }) => {
     switch (size) {
       case 'large':
-        return '15px 108px';
+        return '15px 0';
       case 'medium':
-        return '13px 40px';
+        return '13px 0';
       case 'small':
-        return '10px 28px';
+        return '10px 0';
       default:
-        return '48px';
+        return '15px 0';
     }
   }};
   display: flex;

--- a/src/components/organisms/GenreSurveyForm.tsx
+++ b/src/components/organisms/GenreSurveyForm.tsx
@@ -65,7 +65,7 @@ const GenreSurveyForm = () => {
         type="submit"
         state={countSelectedGenre(genreList) === 3}
       >
-        다음으로
+        다음으로 1/3
       </PrimaryButton>
     </FormContainer>
   );

--- a/src/components/organisms/MovieSurveyForm.tsx
+++ b/src/components/organisms/MovieSurveyForm.tsx
@@ -1,0 +1,129 @@
+import styled from 'styled-components';
+import { useRecoilState } from 'recoil';
+import { useNavigate, useParams } from 'react-router-dom';
+import PrimaryButton from '../atoms/PrimaryButton';
+import {
+  MovieListState,
+  MovieState,
+  movieListState,
+} from '../../store/atoms/Movie/state';
+import MovieSurveyImg from '../atoms/MovieSurveyImg';
+import { MOCK_DATA, MovieSurveyData } from '../template/MovieSurveyTemplate';
+
+const MovieSurveyForm = () => {
+  const [movieList, setMovieList] =
+    useRecoilState<MovieListState>(movieListState);
+
+  const param = useParams();
+  const navigate = useNavigate();
+
+  const countSelectedMovie = (arr: MovieState[]) => {
+    return arr.filter((value) => value.selected).length;
+  };
+
+  const handleSelectedMovie = (item: MovieSurveyData) => {
+    if (param.id === '1') {
+      if (countSelectedMovie(movieList.first) < 3) {
+        setMovieList((prev) => ({
+          ...prev,
+          first: prev.first.map((value) =>
+            value.id === item.id
+              ? { ...value, selected: !value.selected }
+              : value,
+          ),
+        }));
+      } else {
+        setMovieList((prev) => ({
+          ...prev,
+          first: prev.first.map((value) =>
+            value.id === item.id ? { ...value, selected: false } : value,
+          ),
+        }));
+      }
+    } else if (param.id === '2') {
+      if (countSelectedMovie(movieList.second) < 3) {
+        setMovieList((prev) => ({
+          ...prev,
+          second: prev.second.map((value) =>
+            value.id === item.id
+              ? { ...value, selected: !value.selected }
+              : value,
+          ),
+        }));
+      } else {
+        setMovieList((prev) => ({
+          ...prev,
+          second: prev.second.map((value) =>
+            value.id === item.id ? { ...value, selected: false } : value,
+          ),
+        }));
+      }
+    }
+  };
+
+  const handleSurveySubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (param.id === '1') {
+      navigate('/survey/movies/2');
+    } else {
+      navigate('/survey/success');
+    }
+  };
+
+  return (
+    <FormContainer onSubmit={handleSurveySubmit}>
+      <MovieContainer>
+        {MOCK_DATA.map((item) => (
+          <MovieButton
+            type="button"
+            key={item.id}
+            onClick={() => handleSelectedMovie(item)}
+          >
+            <MovieSurveyImg
+              src={item.image}
+              isChecked={
+                param.id === '1'
+                  ? movieList.first.find((value) => value.id === item.id)
+                      ?.selected || false
+                  : movieList.second.find((value) => value.id === item.id)
+                      ?.selected || false
+              }
+            />
+          </MovieButton>
+        ))}
+      </MovieContainer>
+      <PrimaryButton
+        size="medium"
+        type="submit"
+        state={
+          param.id === '1'
+            ? countSelectedMovie(movieList.first) > 0
+            : countSelectedMovie(movieList.second) > 0
+        }
+      >
+        다음으로 {String(Number(param.id) + 1)}/3
+      </PrimaryButton>
+    </FormContainer>
+  );
+};
+
+export default MovieSurveyForm;
+
+const FormContainer = styled.form`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const MovieContainer = styled.div`
+  width: 300px;
+  height: 420px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 56px;
+`;
+
+const MovieButton = styled.button``;

--- a/src/components/organisms/MovieSurveyForm.tsx
+++ b/src/components/organisms/MovieSurveyForm.tsx
@@ -70,6 +70,19 @@ const MovieSurveyForm = () => {
     }
   };
 
+  const handleCheckImg = (item: MovieSurveyData) => {
+    if (param.id === '1') {
+      return (
+        movieList.first.find((value) => value.id === item.id)?.selected || false
+      );
+    } else {
+      return (
+        movieList.second.find((value) => value.id === item.id)?.selected ||
+        false
+      );
+    }
+  };
+
   return (
     <FormContainer onSubmit={handleSurveySubmit}>
       <MovieContainer>
@@ -79,16 +92,7 @@ const MovieSurveyForm = () => {
             key={item.id}
             onClick={() => handleSelectedMovie(item)}
           >
-            <MovieSurveyImg
-              src={item.image}
-              isChecked={
-                param.id === '1'
-                  ? movieList.first.find((value) => value.id === item.id)
-                      ?.selected || false
-                  : movieList.second.find((value) => value.id === item.id)
-                      ?.selected || false
-              }
-            />
+            <MovieSurveyImg src={item.image} isChecked={handleCheckImg(item)} />
           </MovieButton>
         ))}
       </MovieContainer>
@@ -101,7 +105,7 @@ const MovieSurveyForm = () => {
             : countSelectedMovie(movieList.second) > 0
         }
       >
-        다음으로 {String(Number(param.id) + 1)}/3
+        다음으로 {Number(param.id) + 1}/3
       </PrimaryButton>
     </FormContainer>
   );

--- a/src/components/template/GenreSurveyTemplate.tsx
+++ b/src/components/template/GenreSurveyTemplate.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import GenreSurveyForm from '../molecules/GenreSurveyForm';
+import GenreSurveyForm from '../organisms/GenreSurveyForm';
 import Description from '../atoms/Description';
 
 const GenreSurveyTemplate = () => {

--- a/src/components/template/MovieSurveyTemplate.tsx
+++ b/src/components/template/MovieSurveyTemplate.tsx
@@ -1,0 +1,70 @@
+import styled from 'styled-components';
+import { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+import { useParams } from 'react-router-dom';
+import Description from '../atoms/Description';
+import MovieSurveyForm from '../organisms/MovieSurveyForm';
+import { MovieListState, movieListState } from '../../store/atoms/Movie/state';
+
+export interface MovieSurveyData {
+  id: number;
+  image: string;
+}
+
+export const MOCK_DATA: MovieSurveyData[] = [
+  { id: 1, image: '' },
+  { id: 2, image: '' },
+  { id: 3, image: '' },
+  { id: 4, image: '' },
+  { id: 5, image: '' },
+  { id: 6, image: '' },
+  { id: 7, image: '' },
+  { id: 8, image: '' },
+  { id: 9, image: '' },
+];
+
+const MovieSurveyTemplate = () => {
+  const [movieList, setMovieList] =
+    useRecoilState<MovieListState>(movieListState);
+  const param = useParams();
+
+  useEffect(() => {
+    const updateData = MOCK_DATA.map((item) => ({ ...item, selected: false }));
+    if (param.id === '1') {
+      setMovieList((prev) => {
+        return {
+          ...prev,
+          first: updateData,
+        };
+      });
+    } else if (param.id === '2') {
+      setMovieList((prev) => {
+        return {
+          ...prev,
+          second: updateData,
+        };
+      });
+    }
+  }, [param]);
+
+  return (
+    <TemplateContainer>
+      <Description
+        title="관심있는 영화를 선택해주세요"
+        content="최대 3가지의 영화를 선택하실 수 있습니다"
+        state="survey"
+      />
+      <MovieSurveyForm />
+    </TemplateContainer>
+  );
+};
+
+export default MovieSurveyTemplate;
+
+const TemplateContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 108px 40px;
+  gap: 40px;
+`;

--- a/src/components/template/SucessTemplate.tsx
+++ b/src/components/template/SucessTemplate.tsx
@@ -38,7 +38,7 @@ const SucessTemplate = () => {
     if (location.pathname === successPath[0]) {
       navigate('/login');
     } else if (location.pathname === successPath[1]) {
-      navigate('/main');
+      navigate('/');
     }
   };
   return (
@@ -69,7 +69,7 @@ const TemplateContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-top: 260px;
+  padding: 260px 40px 80px 40px;
 `;
 
 const FieldContainer = styled.div`

--- a/src/layout/MainLayout.tsx
+++ b/src/layout/MainLayout.tsx
@@ -34,7 +34,8 @@ export default MainLayout;
 
 const Container = styled.div`
   width: 100%;
-  height: 100vh;
+  height: 100%;
+  min-height: 100vh;
   position: relative;
   background-color: ${({ theme }) => theme.colors.darkgray2};
 `;

--- a/src/store/atoms/Movie/state.ts
+++ b/src/store/atoms/Movie/state.ts
@@ -1,0 +1,19 @@
+import { atom } from 'recoil';
+import { MovieSurveyData } from '../../../components/template/MovieSurveyTemplate';
+
+export interface MovieState extends MovieSurveyData {
+  selected: boolean;
+}
+
+export interface MovieListState {
+  first: MovieState[];
+  second: MovieState[];
+}
+
+export const movieListState = atom<MovieListState>({
+  key: 'movieListState',
+  default: {
+    first: [],
+    second: [],
+  },
+});


### PR DESCRIPTION
- feat 
  - 영화 설문 form 및 템플릿 구현했습니다.
  - 영화설문은 2개의 페이지로 동작하기때문에 다음과 같이 구현했습니다. 
     -  첫번째 페이지와 두번째 페이지에서 각각 영화를 선택하기때문에 한곳에 저장하기위해  recoil을 사용해  first와 Second로 구현  
     -   params에따라  로직 변경 
     

- fix
  -  svg 수정 , layout 수정 , children type 수정 
  -  button 크기 수정
  
- 추후에 해야될일 
  - API 배포되면 MOCKUP-DATA 수정  